### PR TITLE
remove junit dependency from runtime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,8 +72,7 @@ dependencies {
     // Use the Kotlin JDK 8 standard library.
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    // This dependency is used by the application.
-    implementation("org.junit.jupiter:junit-jupiter:5.8.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
 
     // Use the Kotlin JUnit integration.
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")


### PR DESCRIPTION
I was working on adding this library to support `Firefox Profiler` output in the [ap-agent](https://github.com/dpsoft/ap-agent) project and @dpsoft realized that this library brings junit as a runtime dependency.  Despite [this](https://github.com/parttimenerd/jfrtofp/compare/main...lucasamoroso:jfrtofp:feature/junit-runtime-dependency?expand=1#diff-c0dfa6bc7a8685217f70a860145fbdf416d449eaff052fa28352c5cec1a98c06L75) comment the junit dependency seems not be used in the project so I changed the scope to `testImplementation`.